### PR TITLE
修复bug和改善使用体验

### DIFF
--- a/js/components/NAV_LIST.js
+++ b/js/components/NAV_LIST.js
@@ -75,7 +75,8 @@ class NAV_LIST {
     deleteBtn.className = `h-full px-2 rounded text-red-100 bg-red-700 hidden group-hover:block`;
 
     // 删除按钮的点击事件
-    deleteBtn.onclick = () => {
+    deleteBtn.onclick = (event) => {
+      event.stopPropagation(); // 阻止事件冒泡
       if (!confirm(`你确定要删除【${name}】吗？`)) {
         return;
       }
@@ -87,7 +88,7 @@ class NAV_LIST {
       }
       this.refreshDom();
       // 更改右侧界面信息
-      ComponentTextareaContainer.refreshDomByPanelName(name);
+      ComponentTextareaContainer.refreshDomByPanelName(GLOBAL_DATA.currentPanel);
     };
     res.appendChild(deleteBtn);
 

--- a/js/components/componentTextareaContainer.js
+++ b/js/components/componentTextareaContainer.js
@@ -20,11 +20,13 @@ class ComponentTextareaContainer {
    * @param {string} title
    * @param {number} width
    * @param {number} height
+   * @param {string} type
    */
-  constructor(title, width, height) {
+  constructor(title, width, height, type="UNKNOW") {
     this.title = title;
     this.width = width;
     this.height = height;
+    this.type = type;
     this.createTime = new Date();
   }
 
@@ -54,6 +56,7 @@ class ComponentTextareaContainer {
     JSON_STORAGE.set(`${this.title}-data`, {
       width: this.width,
       height: this.height,
+      type: this.type,
       createTime: this.createTime.getTime()
     });
 
@@ -110,23 +113,27 @@ class ComponentTextareaContainer {
     const panelList = JSON_STORAGE.get("panelList");
     if (!panelList.includes(title)) {
       console.warn(`没从缓存中找到${title}的面板`);
+      let res = new ComponentTextareaContainer(title, 3, 2, "CLASSICS");
+      res.createTime = new Date();
+      return res;
     }
 
     const obj = JSON_STORAGE.get(`${title}-data`);
     if (obj === null) {
       // 说明是老版本，经典六宫格
-      let res = new ComponentTextareaContainer(title, 3, 2);
+      let res = new ComponentTextareaContainer(title, 3, 2, "CLASSICS");
       res.createTime = new Date();
       // 顺手更新一下date数据
       JSON_STORAGE.set(`${title}-data`, {
         width: 3,
         height: 2,
+        type: "CLASSICS",
         createTime: res.createTime.getTime()
       });
       return res;
     } else {
       // 新版本
-      let res = new ComponentTextareaContainer(title, obj.width, obj.height);
+      let res = new ComponentTextareaContainer(title, obj.width, obj.height, obj.type);
       res.createTime = new Date(obj.createTime);
       return res;
     }
@@ -138,6 +145,17 @@ class ComponentTextareaContainer {
   refreshTextArea() {
     const mainEle = document.querySelector("main");
     mainEle.innerHTML = "";
+
+    // 获取当前日期信息
+    const now = new Date();
+    const currentDay = now.getDate();
+    const currentMonth = now.getMonth();
+    const currentYear = now.getFullYear();
+    let daysOfWeek = ["周日", "周一", "周二", "周三", "周四", "周五", "周六"];
+    let nameOfMonth = ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"];
+    const todayIs = daysOfWeek[now.getDay()];
+    const currentMonthIs = nameOfMonth[currentMonth]
+
     // 修改main的布局分布
     mainEle.style.gridTemplateColumns = `repeat(${this.width}, 1fr)`;
     mainEle.style.gridTemplateRows = `repeat(${this.height}, auto)`;
@@ -149,6 +167,27 @@ class ComponentTextareaContainer {
         textarea.value = "";
       } else {
         textarea.value = textareaValue;
+      }
+
+      // 高亮对应日期宫格的边框
+      if (this.type === "WEEK") {
+        // 周宫格，检查是否是今天
+        const dayName = textarea.value.split("\n")[0];
+        if (dayName === todayIs) {
+          textarea.className = `p-1 bg-transparent text-yellow-200 leading-6 ring ring-inset ring-stone-700 focus:bg-stone-900 ring-1 outline-0 resize-none transition`;
+        }
+      } else if (this.type === "MOON") {
+        // 月宫格，检查日期
+        const dateStr = textarea.value.split("\n")[0].split(" ")[0];
+        if (dateStr === `${currentMonth + 1}月${currentDay}日`) {
+          textarea.className = `p-1 bg-transparent text-yellow-200 leading-6 ring ring-inset ring-stone-700 focus:bg-stone-900 ring-1 outline-0 resize-none transition`;
+        }
+      } else if (this.type === "YEAR") {
+        // 年宫格，检查月份
+        const monthName = textarea.value.split("\n")[0];
+        if (monthName === currentMonthIs) {
+          textarea.className = `p-1 bg-transparent text-yellow-200 leading-6 ring ring-inset ring-stone-700 focus:bg-stone-900 ring-1 outline-0 resize-none transition`;
+        }
       }
 
 

--- a/js/components/dialogAddPanel.js
+++ b/js/components/dialogAddPanel.js
@@ -9,7 +9,7 @@ const PANEL_TYPES = {
   EIGHT: { name: "八宫格", width: 4, height: 2 },
   NINE: { name: "九宫格", width: 3, height: 3 },
   WEEK: { name: "一周七天", width: 7, height: 1 },
-  MOON: { name: "一月表格", width: 7, height: 5 },
+  MOON: { name: "一月表格", width: 7, height: 6},
   YEAR: { name: "一年十二月", width: 4, height: 3 }
 };
 
@@ -76,19 +76,27 @@ class DIALOG_ADD_PANEL extends Dialog {
     let defaultContent = null;
     if (this.currentSelect === "WEEK") {
       defaultContent = [
-        "周一\n",
-        "周二\n",
-        "周三\n",
-        "周四\n",
-        "周五\n",
-        "周六\n",
-        "周日\n"
+        "周一\n\n",
+        "周二\n\n",
+        "周三\n\n",
+        "周四\n\n",
+        "周五\n\n",
+        "周六\n\n",
+        "周日\n\n"
       ];
     } else if (this.currentSelect === "MOON") {
       const currentDate = new Date();
       const currentYear = currentDate.getFullYear();
       const currentMonth = currentDate.getMonth();
       defaultContent = generateCalendarArray(currentYear, currentMonth);
+      const firstDay = new Date(currentYear, currentMonth, 1).getDay();
+      // 获取当月总天数
+      const totalDays = new Date(currentYear, currentMonth + 1, 0).getDate();
+      // 计算当月第一天在表格中的位置
+      let startingIndex = firstDay === 0 ? 6 : firstDay - 1;
+      // 计算横跨的周数
+      let weeksNum = Math.ceil((startingIndex + totalDays) / 7);
+      this.height = weeksNum;
     } else if (this.currentSelect === "YEAR") {
       const months = [
         "一月",
@@ -104,10 +112,16 @@ class DIALOG_ADD_PANEL extends Dialog {
         "十一月",
         "十二月"
       ];
-      defaultContent = months.map((month) => month + "\n");
+      defaultContent = months.map((month) => month + "\n\n");
     }
-    const panel = new ComponentTextareaContainer(this.title, this.width, this.height);
+    const panel = new ComponentTextareaContainer(this.title, this.width, this.height, this.currentSelect);
     panel.create(defaultContent);
+    // 创建完之后自动切换到新建Panel
+    GLOBAL_DATA.update("currentPanel", this.title);
+    NAV_LIST.refreshDom();
+    ComponentTextareaContainer.refreshDomByPanelName(GLOBAL_DATA.currentPanel);
+    // 清空输入框(只有在创建成功之后才清空，在遇到同名的时候不清空，方便用户再次打开进行修改)
+    this.titleInput.value = '';
   }
 }
 
@@ -115,6 +129,7 @@ class DIALOG_ADD_PANEL extends Dialog {
  * 星期一作为第一列，星期日作为最后一列。
  * 将这个6行7列的表格转换成一个一维字符串数组，这个一维数组是从左往右，
  * 从上往下的顺序读取这个月表格里的每一天，例如: arr = ["1月1日", "1月2日", ...]，
+ * 增加了周几的信息
  * 注意这个一维数组固定长度是6*7=42个元素，前后可能有空字符串作为填充
  * @param {number} year
  * @param {number} month
@@ -122,13 +137,14 @@ class DIALOG_ADD_PANEL extends Dialog {
  */
 function generateCalendarArray(year, month) {
   const calendarArray = [];
+  const daysOfWeek = ["周日", "周一", "周二", "周三", "周四", "周五", "周六"];
 
   // 获取当月第一天是星期几
   const firstDay = new Date(year, month, 1).getDay();
   // 获取当月总天数
   const totalDays = new Date(year, month + 1, 0).getDate();
 
-  // 计算星期一在表格中的位置
+  // 计算当月第一天在表格中的位置
   let startingIndex = firstDay === 0 ? 6 : firstDay - 1;
 
   // 填充前面的空字符串
@@ -136,15 +152,18 @@ function generateCalendarArray(year, month) {
     calendarArray.push("");
   }
 
-  // 填充日期
+  // 填充日期和星期几
   for (let day = 1; day <= totalDays; day++) {
-    calendarArray.push(`${month + 1}月${day}日\n`); // 结尾加换行，方便编辑
+    const dayOfWeek = daysOfWeek[new Date(year, month, day).getDay()];
+    calendarArray.push(`${month + 1}月${day}日 ${dayOfWeek}\n\n`);  // 结尾加换行，方便编辑
   }
 
   // 补齐数组长度
-  while (calendarArray.length < 42) {
+  let weeksNum = Math.ceil((startingIndex + totalDays) / 7);
+  while (calendarArray.length < (7 * weeksNum)) {
     calendarArray.push("");
   }
 
   return calendarArray;
 }
+

--- a/js/components/dialogGlobalSettingPanel.js
+++ b/js/components/dialogGlobalSettingPanel.js
@@ -40,7 +40,7 @@ class GLOBAL_SETTINGS_PANEL extends Dialog {
     let a = document.createElement("a");
     a.href = URL.createObjectURL(blob);
     const date = new Date();
-    a.download = `宫格日记本${date.getFullYear()}-${date.getMonth()}-${date.getDate()}导出.json`;
+    a.download = `宫格日记本${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}导出.json`;
 
     document.body.appendChild(a);
     a.click();

--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,5 @@
 window.onload = function() {
+  
   // 初始化缓存，防止一些key没有
   initStorage();
 
@@ -27,6 +28,7 @@ window.onload = function() {
       // 判断是不是要锁住了
       if (GLOBAL_DATA.lockTimeCurrent >= GLOBAL_DATA.lockTimeMax) {
         GLOBAL_DATA.update("isLockCurrent", true);  // 锁住
+        GLOBAL_DATA.update("previousPannel", GLOBAL_DATA.currentPanel);
         GLOBAL_DATA.update("currentPanel", "default");
         NAV_LIST.refreshDom();
         ComponentTextareaContainer.refreshDomByPanelName(GLOBAL_DATA.currentPanel);
@@ -57,10 +59,34 @@ window.onload = function() {
     if (isCtrlPressed && isQKeyPressed) {
       GLOBAL_DATA.update("isLockCurrent", false);
       GLOBAL_DATA.update("lockTimeCurrent", 0);
+      // 恢复被锁之前的Panel
+      GLOBAL_DATA.update("currentPanel", GLOBAL_DATA.previousPannel);
       NAV_LIST.refreshDom();
+      ComponentTextareaContainer.refreshDomByPanelName(GLOBAL_DATA.currentPanel);
     }
   });
+
+   // 初始化 lastDate
+  if (!(GLOBAL_DATA.lastDate)) {
+    GLOBAL_DATA.update("lastDate", new Date().toISOString().slice(0, 10)); // 获取当前日期（YYYY-MM-DD）
+  }
+
+  // 定时检查日期更新，使得跨过零点也不影响日期高亮
+  setInterval(() => {
+    checkDateUpdate();
+  }, 1000 * 60); // 每分钟检查一次
 };
+
+
+function checkDateUpdate() {
+  const currentDate = new Date().toISOString().slice(0, 10); // 获取当前日期（YYYY-MM-DD）
+
+  if (GLOBAL_DATA.lastDate !== currentDate) {
+    GLOBAL_DATA.update("lastDate", currentDate); // 更新 GLOBAL_DATA.lastDate
+    window.location.reload(); // 刷新页面
+  }
+}
+
 
 /**
  * 刷新一次剩余缓存
@@ -83,6 +109,7 @@ function initStorage() {
     JSON_STORAGE.set(`default-data`, {
       width: 3,
       height: 2,
+      type: "CLASSICS",
       createTime: new Date().getTime()
     });
     for (let i = 0; i < 6; i++) {

--- a/js/service/globalData.js
+++ b/js/service/globalData.js
@@ -8,9 +8,11 @@ const GLOBAL_DATA = {
   // 是否开启隐私保护
   lock: false,
   // 当前是否是锁的状态，只要让这个值=true，整个系统就能保证锁住了
-  isLockCurrent: true,
+  isLockCurrent: false,  //初始时刻不要锁住，用户一开始创建宫格会发现看不到新建宫格。
   lockTimeCurrent: 0,  // 到达60秒的时候锁住
   lockTimeMax: 60,
+  lastDate: null,    //记录日期，用于在日期变更时自动刷新。
+  previousPannel: "default",   //用于记录在锁住之前的pannel，以便解锁的时候自动打开。
 
   /**
    * 更新全局信息

--- a/js/systems/jsonStorage.js
+++ b/js/systems/jsonStorage.js
@@ -79,4 +79,13 @@ const JSON_STORAGE = {
     }
     return JSON.stringify(data);
   },
+  /**
+   * 清空所有缓存数据！！非必要不要使用！仅用作调试！
+   */
+  clearAll() {
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+      const key = localStorage.key(i);
+      localStorage.removeItem(key);
+    }
+  },
 };


### PR DESCRIPTION
【bug修复】
1. 修复导出文件名的月份错误；
2. 修复月份显示错误，比如2024年12月将会横跨6个星期，但是原版本只能显示前5星期。修复思路是创建月面板的时候自动计算该月横跨的周数；
3. 删除panel时会残留数据。这里边包含两部分原因，第一个原因是月面板的height是5，而实际数据量是7×6，这就导致最后7格数据删不掉；第二个原因来自于事件冒泡bug，当点击删除按钮时会同时触发点击对应panel的操作，因此在执行完删除之后会再执行点击操作，导致(1)导致额外添加了数据进json_storage；(2)本来删除后应该自动打开default的，结果触发的点击操作使得左面板的default并没有绿色框。该bug已被修复。
【功能改善】
1. 自动根据宫格类型是否为周、月、年以及当前日期来给对应格子的文字进行高亮。为了实现这个功能，给panel增加了type属性。
2. 月面板的初始文本增加了“周几”。
3. 创建新宫格之后会自动打开新宫格。
4. 在隐私模式下，解锁后会自动打开被锁前的对应宫格。
5. 自动检测日期变更，如果日期发生变更，会自动刷新页面，使得相应日期高亮会自动变化。这个功能有利于用户长时间打开不关闭的情况。
6. 用户首次使用将不再是锁住的状态，以免被用户认为创建panel失败。